### PR TITLE
Add an optional argument to remove the forced `write` and `flush`

### DIFF
--- a/merge_by_lev/main.py
+++ b/merge_by_lev/main.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from functools import lru_cache
 from io import TextIOWrapper
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -259,6 +259,7 @@ def merge_by_similarity(
     merge_mode: bool = False,
     manually: bool = False,
     drop_empty: bool = False,
+    stdout: Any = sys.stdout,
 ) -> Tuple[List[DataFrame], List[str], ndarray]:
     """
     It makes use of the levenshtein distance to calculate
@@ -282,7 +283,7 @@ def merge_by_similarity(
     idx_to_exclude = []
     full_col_list_idx = list(range(len(col_list)))
     count = 0
-    for idx in progressbar(range(len(col_list)), "Computing: "):
+    for idx in progressbar(range(len(col_list)), "Computing: ", out=stdout):
         for i in full_col_list_idx:
             if idx != i:
                 if i not in idx_to_exclude:


### PR DESCRIPTION
Hola, necesito quitar algunos prints innecesarios, como estas usando un `file=out` y estás usando `sys.stdout` en el progress bar, no encontré otra manera más que pasando un parámetro para sobrescribir este comportamiento.